### PR TITLE
Fixing method of identifying prefix

### DIFF
--- a/commands/createcommand.js
+++ b/commands/createcommand.js
@@ -8,8 +8,9 @@ exports.system = true;
 // Don't use this on your own commands, this is internal use only.
 exports.ignoredChannels = [];
 exports.command = function(client, message) {
-    var args = message.content.split(" ");
-
+  var content = message.content.split(" ");
+  var args = content.replace(client.prefix, "").split(" ");
+  
     if (args[1] == null) {
         return message.channel.send("[Spark] Please specify the name for the command. If you want to use aliases, type them space-seperated behind the name.");
 

--- a/commands/createcommand.js
+++ b/commands/createcommand.js
@@ -8,9 +8,9 @@ exports.system = true;
 // Don't use this on your own commands, this is internal use only.
 exports.ignoredChannels = [];
 exports.command = function(client, message) {
-  var content = message.content.split(" ");
-  var args = content.replace(client.prefix, "").split(" ");
-  
+    var content = message.content.split(" ");
+    var args = content.replace(client.prefix, "").split(" ");
+
     if (args[1] == null) {
         return message.channel.send("[Spark] Please specify the name for the command. If you want to use aliases, type them space-seperated behind the name.");
 
@@ -35,7 +35,9 @@ exports.command = function(client, message) {
             return message.channel.send("[Spark] This file does already exist. Please try a different name. ")
         }
 
-        fs.writeFile(path.resolve(path.dirname(require.main.filename), "commands/" + data.name + ".js"), "exports.name = \"" + data.name + "\" \nexports.aliases = " + JSON.stringify(data.aliases) + "\nexports.level = 0\nexports.command = function(client, message){\n\n//Write your command functions here.\n\n} ", {options: "utf8"}, (err) => {
+        fs.writeFile(path.resolve(path.dirname(require.main.filename), "commands/" + data.name + ".js"), "exports.name = \"" + data.name + "\" \nexports.aliases = " + JSON.stringify(data.aliases) + "\nexports.level = 0\nexports.command = function(client, message){\n\n//Write your command functions here.\n\n} ", {
+            options: "utf8"
+        }, (err) => {
             if (err) {
                 return message.channel.send("[Spark] Failed to create this file, try to create it manually using this template: ```javascript\nexports.name = \"" + data.name + "\" \nexports.aliases = \"" + JSON.stringify(data.aliases) + "\"\nexports.command = function(client, message){\n\n//Write your command functions here.\n\n} \n```")
             }

--- a/commands/createcommand.js
+++ b/commands/createcommand.js
@@ -8,8 +8,7 @@ exports.system = true;
 // Don't use this on your own commands, this is internal use only.
 exports.ignoredChannels = [];
 exports.command = function(client, message) {
-    var content = message.content.split(" ");
-    var args = content.replace(client.prefix, "").split(" ");
+    var args = message.content.split(" ");
 
     if (args[1] == null) {
         return message.channel.send("[Spark] Please specify the name for the command. If you want to use aliases, type them space-seperated behind the name.");

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -10,7 +10,8 @@ exports.system = true
 const setup = require("../setup.js");
 var childProcess = require("child_process");
 exports.command = function(client, message) {
-    var args = message.content.split(" ")
+  var content = message.content.split(" ");
+  var args = content.replace(client.prefix, "").split(" ");
     if (args[1] == null) {
         args[1] = ""
     }

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -10,8 +10,7 @@ exports.system = true
 const setup = require("../setup.js");
 var childProcess = require("child_process");
 exports.command = function(client, message) {
-    var content = message.content.split(" ");
-    var args = content.replace(client.prefix, "").split(" ");
+    var args = message.content.split(" ")
     if (args[1] == null) {
         args[1] = ""
     }

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -10,8 +10,8 @@ exports.system = true
 const setup = require("../setup.js");
 var childProcess = require("child_process");
 exports.command = function(client, message) {
-  var content = message.content.split(" ");
-  var args = content.replace(client.prefix, "").split(" ");
+    var content = message.content.split(" ");
+    var args = content.replace(client.prefix, "").split(" ");
     if (args[1] == null) {
         args[1] = ""
     }

--- a/setup.js
+++ b/setup.js
@@ -3,6 +3,7 @@
 
 var fs = require("fs")
 const path = require("path");
+const chalk = require("chalk");
 var util = require("./src/util.js")
 module.exports = function(config, local, reload) {
     return new Promise(function(resolve, reject) {
@@ -13,15 +14,18 @@ module.exports = function(config, local, reload) {
             return reject("You forgot to add your config. (https://discordspark.tk/getting-started)")
         }
         if (config.token === null) {
-            return reject("You haven't set up your config correctly, please add your token in the config object. (https://discordspark.tk/getting-started)")
+            return reject(`[${chalk.red("Config error")}] You haven't set up your config correctly, please add your ${chalk.blue("token")}  in the config object. (https://discordspark.tk/getting-started)`)
         }
         if (config.prefix === null) {
-            return reject("You haven't set up your config correctly, please add your prefix in the config object. (https://discordspark.tk/getting-started)")
+            return reject(`[${chalk.red("Config error")}] You haven't set up your config correctly, please add your ${chalk.blue("prefix")} in the config object. (https://discordspark.tk/getting-started)`)
+        }
+        if (/\s+/g.test(config.prefix)) {
+            return reject(`[${chalk.red("Config error")}] You haven't set up your config correctly, you can't have any spaces in your ${chalk.blue("prefix")}. (https://discordspark.tk/getting-started)`)
         }
         fs.access(path.resolve(local, "commands"), fs.constants.R_OK, (err) => {
             if (err) {
                 fs.mkdir(path.resolve(local, "commands"), function(err) {
-                    if(!err){
+                    if (!err) {
                         config.firstTime = true
                     }
                     util.load("cmds", __dirname).then((data) => {
@@ -41,10 +45,13 @@ module.exports = function(config, local, reload) {
     });
 }
 
-function next(commands, local, reload){
+function next(commands, local, reload) {
     return new Promise(function(resolve, reject) {
         util.load("permissions", __dirname, local).then(permissions => {
-            permsDone({commands, permissions}, local, reload).then(resolve).catch(reject)
+            permsDone({
+                commands,
+                permissions
+            }, local, reload).then(resolve).catch(reject)
         }).catch(e => {
             reject(e)
         })


### PR DESCRIPTION
When I tried making a prefix which ended with a space:
EG:  `/HMB `
Instead of identifying the prefix and the first command as [0] it was identifying prefix as [0] and the command as [1]. This is only the case in "createcommand" and "reload" files. (from what I could find)

Hope I was helpful!